### PR TITLE
Python 2.7 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ This code fits the H-alpha, H-beta, and [OIII]5007 lines with single Gaussian pr
 
 ## How to run the code
 
-* The code uses `python 3.6.1`
+* The code uses `python 3.6.1 (also compatible with 2.7.9)`
 
-* Required libraries: `numpy 1.12.1` and `astropy 1.3.2`. Other standard libraries include glob, time, argparse, multiprocessing, subprocess, sys, os.
+* Required libraries: `numpy 1.11.3` and `astropy 1.3.2`. Other standard libraries include glob, time, argparse, multiprocessing, subprocess, sys, os.
 
 The driver code is [stack_driver.py](#stack_driverpy). Before running this code you need to modify a few lines:
 

--- a/stack_driver.py
+++ b/stack_driver.py
@@ -28,7 +28,7 @@ def driver(*args):
     #objects to stack
     tbl=fits.getdata(tblpath, ext=1)
     obj_ind=((tbl['z_mosfire'] < 2.) & (tbl['ha6565_lum'] != -999.))
-    print('Stacking ',tbl['o32'][obj_ind].size,' objs')
+    print('Stacking ',tbl['id'][obj_ind].size,' objs')
 
     obj_ind=obj_ind*1. #convert boolean to 0,1 array
     

--- a/stack_driver.py
+++ b/stack_driver.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 def driver(*args):
     '''
     the first argument is for the spectra stack normalization, and it can be one of these three options: 'Ha', 'Hb', 'UV', 'none'

--- a/stackspec_script.py
+++ b/stackspec_script.py
@@ -133,7 +133,7 @@ def main(specpath,tblpath,obj_ind,outfile,*normto):
     if sys.argv[5] == 'Hb': norm = 1./hblumlist ; normbalm = 1./hb4863_lum
     if sys.argv[5] == 'UV': norm = 1./uvlumlist ; normbalm = 1./luvcorr
     if sys.argv[5] == 'none': norm = np.ones(len(halumlist)) ; normbalm = np.ones(len(ha6565_lum))
-    if (sys.argv[5] != 'Ha') & (sys.argv[5] != 'Hb') & (sys.argv[5] != 'UV') & (sys.argv[5] != 'none')):
+    if ((sys.argv[5] != 'Ha') & (sys.argv[5] != 'Hb') & (sys.argv[5] != 'UV') & (sys.argv[5] != 'none')):
         print('normto keyword should be set to one of these: "Ha","Hb","UV", or "none" ')
 
 #make a grid of wavelength with the desired resolution


### PR DESCRIPTION
Primarily adds a small modification to stack_driver.py which allows compatibility with Python 2.7. Also removes requirement for "o32" to be in the input catalog (which is not listed in the README) and corrects a syntax error in stackspec_script.py.